### PR TITLE
Updated link in CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,5 +4,5 @@ This project follows a [Code of Conduct][code_of_conduct] in order to ensure an 
 Please read the full text for understanding the accepted and unaccepted behavior.
 Please read also the [reporting guidelines][guidelines], in case you encountered or witnessed any misbehavior.
 
-[code_of_conduct]: https://symfony.com/doc/current/contributing/code_of_conduct/index.html
+[code_of_conduct]: https://symfony.com/coc
 [guidelines]: https://symfony.com/doc/current/contributing/code_of_conduct/reporting_guidelines.html


### PR DESCRIPTION
Changed the link to the Code of Conduct from deeplink to https://symfony.com/coc